### PR TITLE
Fix docker environment URL in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ It can either be run locally via `docker-compose`, or on Amazon Lambda.
 5. Run `docker-compose up`.
 
 This will launch the microservice, along with a Redis cache. The service
-is available at `http://mathman.dev`.
+is available at `http://mathman.docker`.
 
 The API interface is `/mml?tex=<tex-string>` or `svg?tex=<tex-string>`.
 


### PR DESCRIPTION
The URL to a docker instance was specified in the readme as `http://mathman.dev` while in `docker-compose.yml` it defaults to `http://mathman.docker`. This change makes the readme consistent with the compose file.